### PR TITLE
Use W for Western hemisphere

### DIFF
--- a/igc_file_reader.py
+++ b/igc_file_reader.py
@@ -37,10 +37,10 @@ class IGCFileReader:
         latitude = float(latitude_str[0:2]) + (float(latitude_str[2:4]) + float(latitude_str[4:7]) / 1000) / 60
         if latitude_sign == "S":
             latitude *= -1
-        longitude_str = b_record[15:24-1] # last is E for East/ O for Ovest
+        longitude_str = b_record[15:24-1] # last is E for East/ W for West
         longitude_sign = b_record[23]
         longitude = float(longitude_str[0:3]) + (float(longitude_str[3:5]) + float(longitude_str[5:8]) / 1000) / 60
-        if longitude_sign == "O":
+        if longitude_sign == "W":
             longitude *= -1
         fix_validity = b_record[24]
         press_alt = int(b_record[25:30])


### PR DESCRIPTION
Per the FAI description of the IGC file format, W is the character for the Western hemisphere, not O. See page 32 on this PDF: https://www.fai.org/sites/default/files/igc_fr_specification_2022_with_al7_2022-1-31.pdf

I was unable to find any file description that indicated O as a valid character.